### PR TITLE
Add bulk method

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ Storage<User> storage = new xxxStorage<>(
 
 // store new user
 storage.store(new User("fbar", "foo", "bar"));
+// store multiple user
+List<User> users = new ArrayList();
+users.add(new User("fbar2", "foo2", "bar2");
+users.add(new User("fbar3", "foo3", "bar3");
+storage.bulk(users);
+// store multiple user with custom ID
+Map<User> users = new HashMap();
+users.put("id2", new User("fbar2", "foo2", "bar2");
+users.add("id3", new User("fbar3", "foo3", "bar3");
+storage.bulk(users);
+
 // list all users
 Collection<User> users = storage.list();
 // update user

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -11,12 +11,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>storeit-core</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>com.ingensi.data</groupId>
         <artifactId>storeit</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 </project>

--- a/core/src/main/java/com/ingensi/data/storeit/Storage.java
+++ b/core/src/main/java/com/ingensi/data/storeit/Storage.java
@@ -9,6 +9,8 @@ package com.ingensi.data.storeit;
 import com.ingensi.data.storeit.entities.StoredEntity;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 /**
@@ -50,6 +52,15 @@ public interface Storage<T extends StoredEntity> {
     void store(T entity) throws StorageException;
 
     /**
+     * Bulk store new entities. The given entities ids will be used as IDs in the storage.
+     *
+     * @param entityList The list of entities to store
+     * @throws AlreadyExistsException If an ID already exists in the storage.
+     * @throws StorageException       When another error appends.
+     */
+    void bulk(List<T> entityList) throws StorageException;
+
+    /**
      * Store new entity with custom id.
      *
      * @param entity The entity to store.
@@ -58,6 +69,15 @@ public interface Storage<T extends StoredEntity> {
      * @throws StorageException       When another error appends.
      */
     void store(T entity, String id) throws StorageException;
+
+    /**
+     * Bulk store new entities with custom id.
+     *
+     * @param entities The map of ID/entities to store
+     * @throws AlreadyExistsException If an ID already exists in the storage.
+     * @throws StorageException       When another error appends.
+     */
+    void bulk(Map<String, T> entities) throws StorageException;
 
     /**
      * Get an entity from its ID.

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -11,20 +11,20 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>storeit-elasticsearch</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>com.ingensi.data</groupId>
         <artifactId>storeit</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>com.ingensi.data</groupId>
             <artifactId>storeit-core</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.3-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/elasticsearch/src/main/java/com/ingensi/data/storeit/ElasticsearchStorage.java
+++ b/elasticsearch/src/main/java/com/ingensi/data/storeit/ElasticsearchStorage.java
@@ -8,17 +8,17 @@ package com.ingensi.data.storeit;
 
 import com.ingensi.data.storeit.entities.StoredEntity;
 import com.ingensi.data.storeit.mapper.GenericMapper;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.search.SearchHit;
 
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -78,6 +78,15 @@ public class ElasticsearchStorage<T extends StoredEntity> implements Storage<T> 
     }
 
     @Override
+    public void bulk(List<T> entityList) throws StorageException {
+        Map<String, T> entities = new HashMap<>();
+        for (T t : entityList) {
+            entities.put(t.getId(), t);
+        }
+        bulk(entities);
+    }
+
+    @Override
     public void store(T entity, String id) throws StorageException {
         if (!exists(id)) {
             IndexRequestBuilder requestBuilder = client.prepareIndex(index, type);
@@ -97,6 +106,16 @@ public class ElasticsearchStorage<T extends StoredEntity> implements Storage<T> 
         } else {
             throw new AlreadyExistsException("Unable to create entity with id " + id + " (already exists)");
         }
+    }
+
+    @Override
+    public void bulk(Map<String, T> entities) throws StorageException {
+        for (String id : entities.keySet()) {
+            if (exists(id)) {
+                throw new AlreadyExistsException("Unable to create entity with id " + id + " (already exists)");
+            }
+        }
+        bulkCreateOrUpdate(entities);
     }
 
     @Override
@@ -135,6 +154,29 @@ public class ElasticsearchStorage<T extends StoredEntity> implements Storage<T> 
 
         if (!response.isFound()) {
             throw new NotFoundException("Unable to delete entity with id " + id + " (not found)");
+        }
+    }
+
+    private void bulkCreateOrUpdate(Map<String, T> entities) throws StorageException {
+        BulkRequestBuilder bulkRequest = client.prepareBulk();
+
+        for (Map.Entry<String, T> entry : entities.entrySet()) {
+            String id = entry.getKey();
+            T entity = entry.getValue();
+
+            IndexRequestBuilder requestBuilder = client.prepareIndex(index, type);
+
+            if (id != null) {
+                requestBuilder.setId(id);
+            }
+            requestBuilder.setSource(mapper.getTo().build(entity));
+            bulkRequest.add(requestBuilder);
+
+        }
+
+        BulkResponse bulkResponse = bulkRequest.execute().actionGet();
+        if (bulkResponse.hasFailures()) {
+            throw new InternalStorageException("Problem while bulk insert : " + bulkResponse.buildFailureMessage());
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.ingensi.data</groupId>
     <artifactId>storeit</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Light package used to store entities to various storage</description>


### PR DESCRIPTION
Resolve #8 issue.

Add a bulk method to store a List of entities.

I use the Bulk API (http://www.elastic.co/guide/en/elasticsearch/reference/1.5/docs-bulk.html) to do that

I think it should work but I have not tested yet in real conditions.
